### PR TITLE
Center sidebar text

### DIFF
--- a/vertical-slider-cover-card.js
+++ b/vertical-slider-cover-card.js
@@ -307,6 +307,7 @@ class VerticalSliderCoverCard extends LitElement {
           font-weight:400;
           font-size: var(--title-size);
           line-height: var(--title-size);
+          text-align: center;
         }
         .side .center  h3 {
           color:#FFF;
@@ -314,6 +315,7 @@ class VerticalSliderCoverCard extends LitElement {
           font-size: 120%;
           font-weight: 400;
           line-height: 100%;
+          text-align: center;
         }
         
         .side .bottom {


### PR DESCRIPTION
Putting the sidebar text with `text-align: center` makes it a bit cleaner imho. Definitely when you're using a title that wraps to two lines.